### PR TITLE
Remove dependency of tk and add bpe_simple_vocab_16e6.txt.gz in package

### DIFF
--- a/hpsv2/src/open_clip/factory.py
+++ b/hpsv2/src/open_clip/factory.py
@@ -5,7 +5,6 @@ import pathlib
 import re
 from copy import deepcopy
 from pathlib import Path
-from turtle import forward
 from typing import Any, Dict, Optional, Tuple, Union
 
 import torch

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ URL = 'https://github.com/tgxs002/HPSv2'
 EMAIL = 'wangzhih02@gmail.com'
 AUTHOR = 'Zhiheng Wang et al.'
 REQUIRES_PYTHON = '>=3.6.0'
-VERSION = '1.2.0'
+VERSION = '1.2.1'
 
 # What packages are required for this module to be executed?
 REQUIRED = [
@@ -131,7 +131,7 @@ setup(
     #     'console_scripts': ['mycli=mymodule:cli'],
     # },
     package_data={
-        'hpsv2': ['configs/*', 'assets/*', 'tests/**/*'],
+        'hpsv2': ['configs/*', 'assets/*', 'tests/**/*', 'src/open_clip/bpe_simple_vocab_16e6.txt.gz'],
         'hpsv2.src.open_clip': ['**/*'],
         'hpsv2.src.training': ['*']
     },


### PR DESCRIPTION
Hey, two tiny fix

1. `turtle` is imported and it's not used, but it take a dependency on tk, which is hard to install on different machine(different on macos and linux)
2. add bpe_simple_vocab_16e6.txt.gz in package. For now it's unavailable and we need to manually wget 